### PR TITLE
Update NativeFileSystemChangeWatcher to filter on LastWrite only

### DIFF
--- a/LustreCollector/FileSystem/NativeFileSystemChangeWatcher.cs
+++ b/LustreCollector/FileSystem/NativeFileSystemChangeWatcher.cs
@@ -36,7 +36,7 @@ public class NativeFileSystemChangeWatcher : IFileSystemChangeWatcher
     {
         var watcher = new FileSystemWatcher(config.MountPoint, "*.*");
         watcher.InternalBufferSize = config.FileWatcherBufferSize;
-        watcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.LastAccess;
+        watcher.NotifyFilter = NotifyFilters.LastWrite;
         watcher.IncludeSubdirectories = true;
         return watcher;
     }


### PR DESCRIPTION
This is to attempt to avoid `InternalBufferOverflowException` error